### PR TITLE
fix: writing-mode: initial != horizontal-tb at chrome

### DIFF
--- a/packages/postcss-reduce-initial/data/toInitial.json
+++ b/packages/postcss-reduce-initial/data/toInitial.json
@@ -29,6 +29,5 @@
   "text-emphasis-position": "over right",
   "transform-box": "border-box",
   "transform-origin": "50% 50% 0",
-  "vertical-align": "baseline",
-  "writing-mode": "horizontal-tb"
+  "vertical-align": "baseline"
 }


### PR DESCRIPTION
In some cases, writing-mode: initial != horizontal-tb 